### PR TITLE
Add lowerCase and titleCase naming

### DIFF
--- a/thaum/files/template.go
+++ b/thaum/files/template.go
@@ -4,6 +4,7 @@ import (
 	mustache "github.com/Flaque/thaum/thaum/mustache"
 	output "github.com/Flaque/thaum/thaum/output"
 	util "github.com/Flaque/thaum/thaum/util"
+	modifiers "github.com/Flaque/thaum/thaum/modifiers"
 	"github.com/spf13/afero"
 	"os"
 )
@@ -27,9 +28,14 @@ type TemplateFile struct {
 // Updates the TemplateFiles inside the template
 func (t Template) Update() Template {
 	for i, f := range t.Files {
-		for name := range t.Variables {
-			f.variables[name] = t.Variables[name] // Set value
-			t.Files[i] = f
+        for name := range f.variables {
+            if modifiers.VariableHasModifier(name) {
+            	value := t.Variables[modifiers.GetKey(name)]
+                f.variables[name] = modifiers.ApplyModifier(name, value)
+            } else {
+                f.variables[name] = t.Variables[name] // Set value
+            }
+            t.Files[i] = f
 		}
 	}
 	return t

--- a/thaum/modifiers/modifiers.go
+++ b/thaum/modifiers/modifiers.go
@@ -1,0 +1,34 @@
+package modifiers
+
+import "strings"
+
+func lowerCase(content string) string {
+    return strings.ToLower(content)
+}
+
+func titleCase(content string) string {
+    return strings.Title(content)
+}
+
+func ApplyModifier(variable, value string) string {
+    switch modifier := GetModifier(variable); modifier {
+        case "lowerCase":
+            return lowerCase(value)
+        case "titleCase":
+            return titleCase(value)
+        default:
+            return value
+    }
+}
+
+func VariableHasModifier(variable string) bool {
+    return strings.Contains(variable, " ")
+}
+
+func GetKey(variable string) string {
+    return strings.Split(variable, " ")[0]
+}
+
+func GetModifier(variable string) string {
+    return strings.Split(variable, " ")[1]
+}

--- a/thaum/mustache/mustache.go
+++ b/thaum/mustache/mustache.go
@@ -29,7 +29,7 @@ func getKeys(m map[string]bool) []string {
 func FindVariables(content string) []string {
 	variables := make(map[string]bool)
 
-	re := regexp.MustCompile("({{)[A-Za-z]*(}})") // matches {{blah}} types
+	re := regexp.MustCompile("({{)[A-Za-z ]*(}})") // matches {{blah}} or {{blah mod}} types
 	matches := re.FindAllString(content, -1)
 	for _, match := range matches {
 		match := strings.TrimPrefix(match, "{{")

--- a/thaum/util/util.go
+++ b/thaum/util/util.go
@@ -1,5 +1,7 @@
 package util
 
+import modifiers "github.com/Flaque/thaum/thaum/modifiers"
+
 func Keys(m map[string]string) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
@@ -10,7 +12,8 @@ func Keys(m map[string]string) []string {
 
 func AddStringsToSet(strs []string, set map[string]string) map[string]string {
 	for _, s := range strs {
-		set[s] = ""
+        // only add variable names, without the modifier
+		set[modifiers.GetKey(s)] = ""
 	}
 	return set
 }


### PR DESCRIPTION
Solves: https://github.com/Flaque/thaum/issues/5

This was my approach:
1. I modified the regex in `mustache.go` so that it also matches two word variables.
2. These `<modifier> <key>` variables are added to the `variables` map in `TemplateFile` but not to `Template`. That way we don't ask the user for it's value but we pass them on to mustache later on.
3. When setting the values inside `Template.Update`, if the variable has a modifier, apply said modifier and then set the value.

So far I only added two modifiers (`lowerCase` and `titleCase`) but I could add more later if you like my approach and this PR is merged.
I'd also like to add some tests. But I will do that once the final code is approved by you.

**Disclaimer:** This is my first ever PR in go, so please have no mercy and try to be explanative, I'm here to learn 😄 